### PR TITLE
Unify print session state

### DIFF
--- a/facturador/print_manager.py
+++ b/facturador/print_manager.py
@@ -18,40 +18,36 @@ from logger_config import get_printer_logger
 
 printer_logger = get_printer_logger()
 
+# Estructura de ``st.session_state['print_job']`` utilizada para controlar el
+# proceso de impresión.  Cada clave se actualiza en diferentes etapas del flujo:
+#
+# ``cuf`` y ``numero_factura`` se establecen cuando una factura es validada.
+# ``datos_impresion`` guarda la información necesaria para generar el HTML de la
+# factura.
+# ``html_content`` se asigna justo antes de iniciar la impresión.
+# ``print_status`` proporciona retroalimentación a la UI durante todo el
+# proceso.
+# ``in_progress`` y ``finalizado`` indican el estado del hilo de impresión.
+PRINT_JOB_DEFAULTS = {
+    'cuf': None,
+    'numero_factura': None,
+    'html_content': None,
+    'print_status': None,
+    'datos_impresion': {},
+    'in_progress': False,
+    'finalizado': False,
+}
+
 def initialize_print_state():
-    """
-    Inicializa el estado de impresión en la sesión de Streamlit.
-    
-    Esta función establece los valores predeterminados para el estado
-    de impresión en la sesión de Streamlit.
-    """
-    keys_defaults = {
-        'print_status': None,
-        'datos_impresion': {},
-        'cuf': None,
-        'ultima_factura': None,
-        'impresion_en_progreso': False,
-        'impresion_finalizada': False
-    }
-    for key, default in keys_defaults.items():
-        if key not in st.session_state:
-            st.session_state[key] = default
+    """Prepara ``st.session_state['print_job']`` con valores por defecto."""
+    if 'print_job' not in st.session_state:
+        st.session_state['print_job'] = PRINT_JOB_DEFAULTS.copy()
 
 def reiniciar_estados():
-    """
-    Reinicia los estados de impresión en la sesión de Streamlit.
-    
-    Esta función elimina las claves relacionadas con la impresión
-    de la sesión de Streamlit.
-    """
-    keys_to_reset = [
-        'factura_validada', 'print_status', 'datos_impresion', 
-        'cuf', 'ultima_factura', 'impresion_en_progreso', 
-        'impresion_finalizada'
-    ]
-    for key in keys_to_reset:
-        if key in st.session_state:
-            del st.session_state[key]
+    """Restablece los valores del trabajo de impresión."""
+    st.session_state['print_job'] = PRINT_JOB_DEFAULTS.copy()
+    if 'factura_validada' in st.session_state:
+        del st.session_state['factura_validada']
 
 def imprimir_en_hilo(html_content_orig, cuf, nit, numero_factura):
     """
@@ -99,7 +95,7 @@ def imprimir_en_hilo(html_content_orig, cuf, nit, numero_factura):
                 printer = ThermalPrinter()
                 success = printer.print_invoice(html_content, nit, cuf, numero_factura)
                 if success:
-                    st.session_state['print_status'] = "✅ Impresión completada exitosamente"
+                    st.session_state['print_job']['print_status'] = "✅ Impresión completada exitosamente"
                 else:
                     raise Exception("Error durante la impresión térmica")
             except Exception as e:
@@ -117,13 +113,13 @@ def imprimir_en_hilo(html_content_orig, cuf, nit, numero_factura):
             error_msg = f"❌ Error de impresión: {str(e)}"
             printer_logger.error(error_msg)
             printer_logger.error(traceback.format_exc())
-            st.session_state['print_status'] = error_msg
+            st.session_state['print_job']['print_status'] = error_msg
         finally:
-            st.session_state['impresion_en_progreso'] = False
-            st.session_state['impresion_finalizada'] = True
+            st.session_state['print_job']['in_progress'] = False
+            st.session_state['print_job']['finalizado'] = True
     
     # Evitar múltiples procesos de impresión simultáneos
-    if st.session_state.get('impresion_en_progreso', False):
+    if st.session_state.get('print_job', {}).get('in_progress', False):
         printer_logger.warning("Se intentó iniciar una nueva impresión mientras otra está en progreso.")
         return
     
@@ -134,13 +130,18 @@ def imprimir_en_hilo(html_content_orig, cuf, nit, numero_factura):
     # Verificar permisos de escritura
     if not os.access('pdfs', os.W_OK):
         printer_logger.error("No hay permisos de escritura en la carpeta pdfs")
-        st.session_state['print_status'] = "❌ No hay permisos de escritura en la carpeta de PDFs"
+        st.session_state['print_job']['print_status'] = "❌ No hay permisos de escritura en la carpeta de PDFs"
         return
     
     # Actualizar el estado e iniciar el hilo de impresión
-    st.session_state['impresion_en_progreso'] = True
-    st.session_state['impresion_finalizada'] = False
-    st.session_state['print_status'] = "⏱️ Impresión en progreso..."
+    st.session_state['print_job'].update({
+        'html_content': html_content_orig,
+        'cuf': cuf,
+        'numero_factura': numero_factura,
+        'in_progress': True,
+        'finalizado': False,
+        'print_status': "⏱️ Impresión en progreso..."
+    })
     
     # Iniciar hilo de impresión
     thread = threading.Thread(target=imprimir)
@@ -154,7 +155,7 @@ def mostrar_mensaje_impresion_en_curso():
     """
     Muestra un mensaje de advertencia en la UI si la impresión está en curso.
     """
-    if st.session_state.get('impresion_en_progreso', False):
+    if st.session_state.get('print_job', {}).get('in_progress', False):
         st.warning("⚠️ La impresión está en curso. Por favor, espera a que finalice antes de iniciar una nueva impresión.")
 
 def process_invoice(subtotal, descuento_adicional, monto_giftcard, lineas_productos, nombre_cliente, fecha_emision, numero_factura, nit, cuf):

--- a/facturador/printer_utils.py
+++ b/facturador/printer_utils.py
@@ -42,33 +42,29 @@ def verificar_impresora():
         return False
 
 def guardar_factura_actual(html_content, cuf, nit, numero_factura):
-    """
-    Guarda los datos de la factura actual en el session_state
-    """
-    st.session_state['factura_actual'] = {
+    """Guarda la información de la factura en ``st.session_state['print_job']``."""
+    if 'print_job' not in st.session_state:
+        st.session_state['print_job'] = {}
+    st.session_state['print_job'].update({
         'html_content': html_content,
         'cuf': cuf,
         'nit': nit,
         'numero_factura': numero_factura,
-        'impresa': False
-    }
+        'impresa': False,
+    })
     printer_logger.info(f"Factura {numero_factura} guardada en session_state")
 
 def obtener_factura_actual():
-    """
-    Obtiene los datos de la factura actual del session_state
-    Returns:
-        dict: Datos de la factura o None si no hay factura
-    """
-    return st.session_state.get('factura_actual')
+    """Retorna los datos de ``print_job`` o ``None`` si no existen."""
+    return st.session_state.get('print_job')
 
 def marcar_factura_impresa():
-    """
-    Marca la factura actual como impresa en el session_state
-    """
-    if 'factura_actual' in st.session_state:
-        st.session_state['factura_actual']['impresa'] = True
-        printer_logger.info(f"Factura {st.session_state['factura_actual']['numero_factura']} marcada como impresa")
+    """Marca la factura actual como impresa en ``print_job``."""
+    if 'print_job' in st.session_state:
+        st.session_state['print_job']['impresa'] = True
+        printer_logger.info(
+            f"Factura {st.session_state['print_job'].get('numero_factura')} marcada como impresa"
+        )
 
 def html_to_escpos_text(html_content):
     """

--- a/facturador/ui_copy.py
+++ b/facturador/ui_copy.py
@@ -236,10 +236,10 @@ def monitorear_hilo_impresion(hilo):
         start_time = time.time()
         status_placeholder.info("⏳ Procesando...")
 
-        while (hilo.is_alive() or st.session_state.get('impresion_en_progreso', False)):
+        while (hilo.is_alive() or st.session_state.get('print_job', {}).get('in_progress', False)):
             if os.path.exists(complete_signal):
-                st.session_state['print_status'] = "✅ Impresión completada exitosamente"
-                st.session_state['impresion_en_progreso'] = False
+                st.session_state['print_job']['print_status'] = "✅ Impresión completada exitosamente"
+                st.session_state['print_job']['in_progress'] = False
                 ui_logger.info(f"Impresión completada para la factura {numero_factura}")
                 os.remove(complete_signal)
                 break
@@ -247,24 +247,24 @@ def monitorear_hilo_impresion(hilo):
             if os.path.exists(error_signal):
                 with open(error_signal, 'r') as f:
                     error_info = f.read().strip()
-                st.session_state['print_status'] = f"❌ {error_info}"
-                st.session_state['impresion_en_progreso'] = False
+                st.session_state['print_job']['print_status'] = f"❌ {error_info}"
+                st.session_state['print_job']['in_progress'] = False
                 ui_logger.error(f"Error en la impresión de la factura {numero_factura}: {error_info}")
                 os.remove(error_signal)
                 break
 
             elapsed_time = time.time() - start_time
             if elapsed_time > timeout:
-                st.session_state['print_status'] = "⚠️ Tiempo de espera excedido, pero el proceso continúa en segundo plano."
-                st.session_state['impresion_en_progreso'] = False
+                st.session_state['print_job']['print_status'] = "⚠️ Tiempo de espera excedido, pero el proceso continúa en segundo plano."
+                st.session_state['print_job']['in_progress'] = False
                 ui_logger.warning(f"Tiempo de espera excedido para la impresión de la factura {numero_factura}")
                 break
 
-            print_status = st.session_state.get('print_status', "⏳ Procesando...")
+            print_status = st.session_state.get('print_job', {}).get('print_status', "⏳ Procesando...")
             status_placeholder.info(print_status)
             time.sleep(0.5)
 
-        final_status = st.session_state.get('print_status', "❓ Estado desconocido.")
+        final_status = st.session_state.get('print_job', {}).get('print_status', "❓ Estado desconocido.")
         if "✅" in final_status:
             status_placeholder.success(final_status)
         elif "❌" in final_status:
@@ -277,7 +277,8 @@ def monitorear_hilo_impresion(hilo):
     except Exception as e:
         st.error(f"❌ Error durante el monitoreo del proceso: {str(e)}")
         ui_logger.exception("Error en monitorear_hilo_impresion")
-        st.session_state['impresion_en_progreso'] = False
+        if 'print_job' in st.session_state:
+            st.session_state['print_job']['in_progress'] = False
 
 # Gestión de pestañas con logs
 def main():
@@ -772,10 +773,10 @@ def main():
                                 if success:
                                     transaccion_exitosa = display_siat_response(response_data, message_placeholder)
                                     if transaccion_exitosa:
-                                        st.session_state['cuf'] = cuf
-                                        st.session_state['ultima_factura'] = numero_factura
+                                        st.session_state['print_job']['cuf'] = cuf
+                                        st.session_state['print_job']['numero_factura'] = numero_factura
                                         st.session_state['factura_validada'] = True
-                                        st.session_state['datos_impresion'] = {
+                                        st.session_state['print_job']['datos_impresion'] = {
                                             'subtotal': subtotal,
                                             'descuento_adicional': descuento_adicional,
                                             'monto_giftcard': monto_giftcard,
@@ -824,31 +825,31 @@ def main():
             mostrar_mensaje_impresion_en_curso()
 
             # Botón para forzar liberación de impresión si está colgada
-            if st.session_state.get('impresion_en_progreso', False):
+            if st.session_state.get('print_job', {}).get('in_progress', False):
                 if st.button("Forzar liberación de impresión", key="forzar_liberacion_impresion"):
-                    st.session_state['impresion_en_progreso'] = False
-                    st.session_state['print_status'] = "⚠️ Impresión liberada manualmente. Puedes volver a intentar imprimir."
+                    st.session_state['print_job']['in_progress'] = False
+                    st.session_state['print_job']['print_status'] = "⚠️ Impresión liberada manualmente. Puedes volver a intentar imprimir."
 
             if st.session_state.get('factura_validada'):
                 # Determinar si el botón de imprimir debe estar desactivado
-                impresion_en_progreso = st.session_state.get('impresion_en_progreso', False)
+                impresion_en_progreso = st.session_state.get('print_job', {}).get('in_progress', False)
                 
                 if st.button("Imprimir Factura", disabled=impresion_en_progreso):
                     try:
                         # Marcar que la impresión está en progreso
-                        st.session_state['impresion_en_progreso'] = True
-                        st.session_state['print_status'] = "⏳ Procesando..."
+                        st.session_state['print_job']['in_progress'] = True
+                        st.session_state['print_job']['print_status'] = "⏳ Procesando..."
                         
                         # Validar que las claves necesarias estén presentes
-                        required_keys = ['datos_impresion', 'cuf', 'ultima_factura']
-                        missing_keys = [key for key in required_keys if key not in st.session_state]
-                        if missing_keys:
-                            st.session_state['print_status'] = f"❌ Faltan datos necesarios: {', '.join(missing_keys)}"
-                            st.session_state['impresion_en_progreso'] = False
-                            printer_logger.error(f"Faltan claves requeridas en session_state: {missing_keys}")
+                        required_keys = ['datos_impresion', 'cuf', 'numero_factura']
+                        missing = [k for k in required_keys if k not in st.session_state.get('print_job', {})]
+                        if missing:
+                            st.session_state['print_job']['print_status'] = f"❌ Faltan datos necesarios: {', '.join(missing)}"
+                            st.session_state['print_job']['in_progress'] = False
+                            printer_logger.error(f"Faltan claves requeridas en session_state: {missing}")
                         else:
                             # Generar contenido HTML para la factura
-                            datos = st.session_state['datos_impresion']
+                            datos = st.session_state['print_job']['datos_impresion']
                             html_content = generate_compact_html_invoice(
                                 subtotal=datos['subtotal'],
                                 descuento_adicional=datos['descuento_adicional'],
@@ -856,7 +857,7 @@ def main():
                                 lineas_productos=datos['lineas_productos'],
                                 nombre_cliente=datos['nombre_cliente'],
                                 fecha_emision=datos['fecha_emision_str'],
-                                numero_factura=st.session_state['ultima_factura'],
+                                numero_factura=st.session_state['print_job']['numero_factura'],
                                 metodo_de_pago=datos.get('seleccion_metodo_pago'),
                                 codigo_clasificador_metodo_pago=datos.get('codigo_clasificador_metodo_pago'),
                                 tipo_documento=datos.get('seleccion_tipo_documento'),
@@ -866,22 +867,22 @@ def main():
                                 email=datos.get('email'),
                                 telefono=datos.get('telefono'),
                                 ultimos_digitos_tarjeta=datos.get('ultimos_digitos_tarjeta'),
-                                cuf=st.session_state['cuf']
+                                cuf=st.session_state['print_job']['cuf']
                             )
                             
                             # Iniciar el hilo de impresión
                             hilo_impresion = imprimir_en_hilo(
                                 html_content,
-                                st.session_state['cuf'],
+                                st.session_state['print_job']['cuf'],
                                 os.getenv('NIT'),
-                                st.session_state['ultima_factura']
+                                st.session_state['print_job']['numero_factura']
                             )
                             
                             # Monitorear el estado del hilo
                             # La función de monitoreo ahora está incorporada en imprimir_en_hilo
                     except Exception as e:
-                        st.session_state['print_status'] = f"❌ Error: {str(e)}"
-                        st.session_state['impresion_en_progreso'] = False
+                        st.session_state['print_job']['print_status'] = f"❌ Error: {str(e)}"
+                        st.session_state['print_job']['in_progress'] = False
                         printer_logger.exception("Error en el proceso de impresión")
             else:
                 st.info("El botón de impresión solo estará disponible cuando la factura haya sido validada exitosamente por el SIN.")
@@ -889,7 +890,11 @@ def main():
         with col3:
             if st.session_state.get('factura_validada'):
                 nit_emisor = int(os.getenv('NIT'))
-                enlace = generate_invoice_link(nit_emisor, st.session_state['cuf'], st.session_state['ultima_factura'])
+                enlace = generate_invoice_link(
+                    nit_emisor,
+                    st.session_state['print_job']['cuf'],
+                    st.session_state['print_job']['numero_factura']
+                )
                 st.link_button("Consultar factura", enlace)
 
     # Pestaña 9: Diagnóstico Avanzado (NUEVA funcionalidad)

--- a/static/sistema-facturacion-doc.md
+++ b/static/sistema-facturacion-doc.md
@@ -189,7 +189,7 @@ Nuestro sistema utiliza las sesiones de manera estratégica para diferentes prop
 
 2. **Almacenamiento de Datos de Factura**
    ```python
-   st.session_state['datos_impresion'] = {
+   st.session_state['print_job']['datos_impresion'] = {
        'subtotal': subtotal,
        'descuento_adicional': descuento_adicional,
        'monto_giftcard': monto_giftcard,
@@ -197,15 +197,15 @@ Nuestro sistema utiliza las sesiones de manera estratégica para diferentes prop
        # ... más datos ...
    }
    ```
-   Aquí guardamos todos los detalles necesarios para imprimir la factura, como si fuera una receta completa con todos sus ingredientes y cantidades.
+   Aquí guardamos todos los detalles necesarios para imprimir la factura.
 
 3. **Control de Estado de Facturación**
    ```python
-   st.session_state['cuf'] = cuf
-   st.session_state['ultima_factura'] = numero_factura
+   st.session_state['print_job']['cuf'] = cuf
+   st.session_state['print_job']['numero_factura'] = numero_factura
    st.session_state['factura_validada'] = True
    ```
-   Estos son como puntos de control que nos dicen en qué parte del proceso estamos y qué se ha completado exitosamente.
+   Estos puntos indican en qué parte del proceso estamos y qué se ha completado.
 
 ### 5.3 Manejo del Estado de Impresión
 


### PR DESCRIPTION
## Summary
- centralize print state in `st.session_state['print_job']`
- update printing utilities and UI to use unified structure
- integrate former `factura_actual` helpers with new design
- document managed keys in code and docs

## Testing
- `python -m py_compile facturador/print_manager.py facturador/printer_utils.py facturador/ui_copy.py`
- `npx pyright` *(fails: requires package install)*

------
https://chatgpt.com/codex/tasks/task_e_686752445524832abeeb5fb9904bdb7c