### PR TITLE
Refactor impresión con resultados en cola

### DIFF
--- a/facturador/print_manager.py
+++ b/facturador/print_manager.py
@@ -7,6 +7,7 @@ y generación de documentos PDF.
 
 import os
 import threading
+import queue
 from datetime import datetime
 import logging
 import traceback
@@ -56,7 +57,8 @@ def reiniciar_estados():
 def imprimir_en_hilo(html_content_orig, cuf, nit, numero_factura):
     """
     Crea un hilo para manejar la impresión de la factura y generación del PDF.
-    Esta función incorpora toda la lógica de monitoreo del hilo.
+    El hilo escribe los resultados en una cola para que la interfaz
+    principal actualice ``st.session_state`` de forma segura.
 
     Args:
         html_content_orig (str): Contenido HTML original de la factura.
@@ -64,6 +66,8 @@ def imprimir_en_hilo(html_content_orig, cuf, nit, numero_factura):
         nit (str): NIT del emisor.
         numero_factura (str): Número de factura.
     """
+    result_queue = queue.Queue()
+
     def imprimir():
         try:
             printer_logger.info(f"Iniciando proceso de impresión para factura {numero_factura}")
@@ -99,7 +103,7 @@ def imprimir_en_hilo(html_content_orig, cuf, nit, numero_factura):
                 printer = ThermalPrinter()
                 success = printer.print_invoice(html_content, nit, cuf, numero_factura)
                 if success:
-                    st.session_state['print_status'] = "✅ Impresión completada exitosamente"
+                    result_queue.put(("success", "✅ Impresión completada exitosamente"))
                 else:
                     raise Exception("Error durante la impresión térmica")
             except Exception as e:
@@ -117,10 +121,9 @@ def imprimir_en_hilo(html_content_orig, cuf, nit, numero_factura):
             error_msg = f"❌ Error de impresión: {str(e)}"
             printer_logger.error(error_msg)
             printer_logger.error(traceback.format_exc())
-            st.session_state['print_status'] = error_msg
+            result_queue.put(("error", error_msg))
         finally:
-            st.session_state['impresion_en_progreso'] = False
-            st.session_state['impresion_finalizada'] = True
+            result_queue.put(("done", None))
     
     # Evitar múltiples procesos de impresión simultáneos
     if st.session_state.get('impresion_en_progreso', False):
@@ -143,12 +146,12 @@ def imprimir_en_hilo(html_content_orig, cuf, nit, numero_factura):
     st.session_state['print_status'] = "⏱️ Impresión en progreso..."
     
     # Iniciar hilo de impresión
-    thread = threading.Thread(target=imprimir)
+    thread = threading.Thread(target=imprimir, name=f"print_{numero_factura}")
     thread.daemon = True
     thread.start()
 
     printer_logger.info(f"Hilo de impresión iniciado para la factura {numero_factura}")
-    return True
+    return thread, result_queue
 
 def mostrar_mensaje_impresion_en_curso():
     """

--- a/facturador/ui_copy.py
+++ b/facturador/ui_copy.py
@@ -5,6 +5,7 @@ import re
 import logging
 import traceback
 import base64
+import queue
 import hashlib
 import xml.etree.ElementTree as ET
 from datetime import datetime
@@ -224,8 +225,10 @@ def render_sidebar():
 
     return numero_documento, nit_valido, nombre_cliente, complemento, email, telefono, seleccion_tipo_documento, codigo_clasificador_documento, codigo_clasificador_metodo_pago, ultimos_digitos_tarjeta, codigo_cliente
 
-# Estas funciones ahora están en print_manager.py def monitorear_hilo_impresion(hilo):
-def monitorear_hilo_impresion(hilo):
+# Monitoreo del hilo de impresión. Actualiza ``st.session_state`` en el hilo principal.
+def monitorear_hilo_impresion(hilo, result_queue=None):
+    """Lee resultados de ``result_queue`` y actualiza ``st.session_state`` mientras
+    el hilo de impresión está en ejecución."""
     try:
         ui_logger.info(f"Iniciando monitoreo del hilo de impresión: {hilo.name}")
         status_placeholder = st.empty()
@@ -237,6 +240,16 @@ def monitorear_hilo_impresion(hilo):
         status_placeholder.info("⏳ Procesando...")
 
         while (hilo.is_alive() or st.session_state.get('impresion_en_progreso', False)):
+            if result_queue is not None:
+                try:
+                    msg_type, msg = result_queue.get_nowait()
+                    if msg_type == "success" or msg_type == "error":
+                        st.session_state['print_status'] = msg
+                    if msg_type == "done":
+                        st.session_state['impresion_en_progreso'] = False
+                        st.session_state['impresion_finalizada'] = True
+                except queue.Empty:
+                    pass
             if os.path.exists(complete_signal):
                 st.session_state['print_status'] = "✅ Impresión completada exitosamente"
                 st.session_state['impresion_en_progreso'] = False
@@ -870,15 +883,14 @@ def main():
                             )
                             
                             # Iniciar el hilo de impresión
-                            hilo_impresion = imprimir_en_hilo(
+                            hilo_impresion, result_queue = imprimir_en_hilo(
                                 html_content,
                                 st.session_state['cuf'],
                                 os.getenv('NIT'),
                                 st.session_state['ultima_factura']
                             )
-                            
-                            # Monitorear el estado del hilo
-                            # La función de monitoreo ahora está incorporada en imprimir_en_hilo
+
+                            monitorear_hilo_impresion(hilo_impresion, result_queue)
                     except Exception as e:
                         st.session_state['print_status'] = f"❌ Error: {str(e)}"
                         st.session_state['impresion_en_progreso'] = False

--- a/static/docs/flujo_impresion_con_hilo.md
+++ b/static/docs/flujo_impresion_con_hilo.md
@@ -1,0 +1,14 @@
+# Flujo actualizado de impresión en hilo
+
+La función `imprimir_en_hilo` ya no modifica directamente `st.session_state` desde el hilo de impresión. 
+En su lugar, el hilo escribe los resultados en una **cola (`queue.Queue`)** y el hilo principal consume esos mensajes
+para actualizar el estado de la interfaz.
+
+1. `imprimir_en_hilo` crea la cola y retorna `(hilo_impresion, cola_resultados)`.
+2. El hilo interno realiza la generación de PDF e impresión. Al completar o al detectar un error coloca
+   en la cola un mensaje del tipo `("success", mensaje)` o `("error", mensaje)` y siempre agrega `("done", None)`
+   al finalizar.
+3. En la UI, `monitorear_hilo_impresion` recibe la cola y actualiza `st.session_state` según los mensajes
+   recibidos, evitando modificaciones directas desde otros hilos.
+
+Este mecanismo previene condiciones de carrera y mantiene la coherencia de `st.session_state`.


### PR DESCRIPTION
## Summary
- update `imprimir_en_hilo` to report results through a queue
- update `monitorear_hilo_impresion` to read the queue and update `st.session_state`
- call monitor after launching the printing thread
- document the new threaded flow

## Testing
- `python -m py_compile facturador/print_manager.py facturador/ui_copy.py`

------
https://chatgpt.com/codex/tasks/task_e_68675a469d04832a992b8ea9996a718f