### PR TITLE
Centralize debug/pdf path resolution

### DIFF
--- a/facturador/print_manager.py
+++ b/facturador/print_manager.py
@@ -16,6 +16,22 @@ from siat_pdf import html_to_pdf
 from thermal_printer import ThermalPrinter
 from logger_config import get_printer_logger
 
+def get_output_dirs():
+    """Obtiene las rutas absolutas de los directorios ``debug/`` y ``pdfs/``.
+
+    Las rutas se calculan de forma relativa a este módulo y se garantiza
+    que ambos directorios existan.
+
+    Returns:
+        tuple[str, str]: Rutas a ``debug/`` y ``pdfs/`` respectivamente.
+    """
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    debug_dir = os.path.join(base_dir, "debug")
+    pdfs_dir = os.path.join(base_dir, "pdfs")
+    os.makedirs(debug_dir, exist_ok=True)
+    os.makedirs(pdfs_dir, exist_ok=True)
+    return debug_dir, pdfs_dir
+
 printer_logger = get_printer_logger()
 
 def initialize_print_state():
@@ -73,11 +89,7 @@ def imprimir_en_hilo(html_content_orig, cuf, nit, numero_factura):
 
             # Guardar HTML para debug y referencia
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            base_dir = os.path.dirname(os.path.abspath(__file__))
-            debug_dir = os.path.join(base_dir, "debug")
-            pdfs_dir = os.path.join(base_dir, "pdfs")
-            os.makedirs(debug_dir, exist_ok=True)
-            os.makedirs(pdfs_dir, exist_ok=True)
+            debug_dir, pdfs_dir = get_output_dirs()
             debug_path = os.path.join(debug_dir, f"factura_{numero_factura}_{timestamp}.html")
             
             with open(debug_path, "w", encoding="utf-8") as f:
@@ -106,7 +118,7 @@ def imprimir_en_hilo(html_content_orig, cuf, nit, numero_factura):
                 raise Exception(f"Error en impresión térmica: {str(e)}")
 
             # Crear un archivo de señalización para indicar que la impresión ha terminado
-            signal_file = f"debug/print_complete_{numero_factura}.signal"
+            signal_file = os.path.join(debug_dir, f"print_complete_{numero_factura}.signal")
             with open(signal_file, "w") as f:
                 f.write(f"Impresión completada: {datetime.now().isoformat()}")
                 f.flush()
@@ -127,12 +139,10 @@ def imprimir_en_hilo(html_content_orig, cuf, nit, numero_factura):
         printer_logger.warning("Se intentó iniciar una nueva impresión mientras otra está en progreso.")
         return
     
-    # Verificar carpeta de destino PDF
-    if not os.path.exists('pdfs'):
-        os.makedirs('pdfs')
-    
-    # Verificar permisos de escritura
-    if not os.access('pdfs', os.W_OK):
+    # Obtener rutas de trabajo y verificar permisos de escritura
+    debug_dir, pdfs_dir = get_output_dirs()
+
+    if not os.access(pdfs_dir, os.W_OK):
         printer_logger.error("No hay permisos de escritura en la carpeta pdfs")
         st.session_state['print_status'] = "❌ No hay permisos de escritura en la carpeta de PDFs"
         return
@@ -187,16 +197,12 @@ def process_invoice(subtotal, descuento_adicional, monto_giftcard, lineas_produc
             numero_factura=numero_factura
         )
 
-        # Guardar HTML para depuración
-        debug_dir = os.path.join(os.getcwd(), "debug")
-        os.makedirs(debug_dir, exist_ok=True)
+        # Guardar HTML y generar PDF en rutas consistentes
+        debug_dir, pdf_dir = get_output_dirs()
         debug_path = os.path.join(debug_dir, f"factura_{numero_factura}.html")
         with open(debug_path, "w", encoding="utf-8") as f:
             f.write(html_content)
 
-        # Generar PDF
-        pdf_dir = os.path.join(os.getcwd(), "pdfs")
-        os.makedirs(pdf_dir, exist_ok=True)
         pdf_path = os.path.join(pdf_dir, f"factura_{numero_factura}_{nit}_{cuf[-8:]}.pdf")
         html_to_pdf(html_content, pdf_path)
 

--- a/facturador/ui_copy.py
+++ b/facturador/ui_copy.py
@@ -53,7 +53,13 @@ from invoice_templates import generate_html_invoice, generate_compact_html_invoi
 from validators import es_email_valido, es_telefono_valido, validar_factura_cabecera, validar_factura_detalle
 from client_manager import save_or_fetch_client_data, verificar_nit_cliente
 from invoice_manager import guardar_factura_en_bd, obtener_y_reservar_numero_factura, mostrar_lista_facturas
-from print_manager import initialize_print_state, reiniciar_estados, imprimir_en_hilo, mostrar_mensaje_impresion_en_curso
+from print_manager import (
+    initialize_print_state,
+    reiniciar_estados,
+    imprimir_en_hilo,
+    mostrar_mensaje_impresion_en_curso,
+    get_output_dirs,
+)
 from xml_signer import sign_xml
 
 # Módulos de servicios SIN
@@ -110,12 +116,10 @@ gift_card_codes = [
 ]
 
 # Agregar al inicio del script o en la configuración inicial
-if not os.path.exists('pdfs'):
-    os.makedirs('pdfs')
-    
-# Agregar al inicio del script
+debug_dir, pdf_dir = get_output_dirs()
+
 try:
-    if not os.access('pdfs', os.W_OK):
+    if not os.access(pdf_dir, os.W_OK):
         logger.error("No hay permisos de escritura en la carpeta pdfs")
         raise PermissionError("No hay permisos de escritura en la carpeta pdfs")
 except Exception as e:
@@ -230,8 +234,9 @@ def monitorear_hilo_impresion(hilo):
         ui_logger.info(f"Iniciando monitoreo del hilo de impresión: {hilo.name}")
         status_placeholder = st.empty()
         numero_factura = hilo.name.split('_')[-1]
-        complete_signal = f"debug/print_complete_{numero_factura}.signal"
-        error_signal = f"debug/print_error_{numero_factura}.signal"
+        debug_dir, _ = get_output_dirs()
+        complete_signal = os.path.join(debug_dir, f"print_complete_{numero_factura}.signal")
+        error_signal = os.path.join(debug_dir, f"print_error_{numero_factura}.signal")
         timeout = 30
         start_time = time.time()
         status_placeholder.info("⏳ Procesando...")


### PR DESCRIPTION
## Summary
- add `get_output_dirs` helper in `print_manager` to always create and access `debug/` and `pdfs/`
- use this helper inside printing logic and UI

## Testing
- `pyright -p testpyrightconfig.json` *(fails: imports not resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68675bdaa7c4832a85a0fc061fbb96f8